### PR TITLE
Feature/15 contact information screen

### DIFF
--- a/src/components/DescContactInfo.js
+++ b/src/components/DescContactInfo.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+const DescContactInfo = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.textInstructions}>
+        Esta información servirá para ponernos en contacto contigo más rapido
+        cuando sea necesario
+      </Text>
+    </View>
+  );
+};
+
+export default DescContactInfo;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 40,
+  },
+  textInstructions: {
+    fontSize: 18,
+    textAlign: 'justify',
+  },
+});

--- a/src/components/DescContactInfo.js
+++ b/src/components/DescContactInfo.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
+import {DESC_CONTACT_INFO} from '../utils/Constants';
 
 const DescContactInfo = () => {
   return (
     <View style={styles.container}>
-      <Text style={styles.textInstructions}>
-        Esta información servirá para ponernos en contacto contigo más rapido
-        cuando sea necesario
-      </Text>
+      <Text style={styles.textInstructions}>{DESC_CONTACT_INFO}</Text>
     </View>
   );
 };

--- a/src/components/EmailPassTxtInput.js
+++ b/src/components/EmailPassTxtInput.js
@@ -11,7 +11,11 @@ const EmailPassTxtInput = (props) => {
           {props.isRequired}
         </Text>
       </View>
-      <TextInput style={styles.textInput} secureTextEntry={props.password} />
+      <TextInput
+        style={styles.textInput}
+        secureTextEntry={props.password}
+        keyboardType={props.keyboard}
+      />
     </View>
   );
 };

--- a/src/navigations/NavigationLogin.js
+++ b/src/navigations/NavigationLogin.js
@@ -13,12 +13,12 @@ const NavigationLogin = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name='Welcome'
+        name="Welcome"
         component={Welcome}
         options={{headerShown: false}}
       />
       <Stack.Screen
-        name='PrivacyPolicy'
+        name="PrivacyPolicy"
         options={{
           title: 'Paso 1 de 4',
           headerStyle: {
@@ -29,7 +29,7 @@ const NavigationLogin = () => {
         component={PrivacyPolicy}
       />
       <Stack.Screen
-        name='RegisterAccount'
+        name="RegisterAccount"
         options={{
           title: 'Paso 2 de 4',
           headerStyle: {
@@ -40,7 +40,7 @@ const NavigationLogin = () => {
         component={RegisterAccount}
       />
       <Stack.Screen
-        name='ConfirmEmail'
+        name="ConfirmEmail"
         options={{
           title: 'Paso 3 de 4',
           headerStyle: {
@@ -51,7 +51,7 @@ const NavigationLogin = () => {
         component={ConfirmEmail}
       />
       <Stack.Screen
-        name='ContactInformation'
+        name="ContactInformation"
         options={{
           title: 'Paso 4 de 4',
           headerStyle: {

--- a/src/navigations/NavigationLogin.js
+++ b/src/navigations/NavigationLogin.js
@@ -5,6 +5,7 @@ import Welcome from '../screens/Welcome';
 import PrivacyPolicy from '../screens/PrivacyPolicy';
 import RegisterAccount from '../screens/RegisterAccount';
 import ConfirmEmail from '../screens/ConfirmEmail';
+import ContactInformation from '../screens/ContactInformation';
 
 const Stack = createStackNavigator();
 
@@ -48,6 +49,17 @@ const NavigationLogin = () => {
           headerTitleAlign: 'center',
         }}
         component={ConfirmEmail}
+      />
+      <Stack.Screen
+        name="ContactInformation"
+        options={{
+          title: 'Paso 4 de 4',
+          headerStyle: {
+            backgroundColor: Colors.btnsColor,
+          },
+          headerTitleAlign: 'center',
+        }}
+        component={ContactInformation}
       />
     </Stack.Navigator>
   );

--- a/src/navigations/NavigationLogin.js
+++ b/src/navigations/NavigationLogin.js
@@ -13,12 +13,12 @@ const NavigationLogin = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name="Welcome"
+        name='Welcome'
         component={Welcome}
         options={{headerShown: false}}
       />
       <Stack.Screen
-        name="PrivacyPolicy"
+        name='PrivacyPolicy'
         options={{
           title: 'Paso 1 de 4',
           headerStyle: {
@@ -29,7 +29,7 @@ const NavigationLogin = () => {
         component={PrivacyPolicy}
       />
       <Stack.Screen
-        name="RegisterAccount"
+        name='RegisterAccount'
         options={{
           title: 'Paso 2 de 4',
           headerStyle: {
@@ -40,7 +40,7 @@ const NavigationLogin = () => {
         component={RegisterAccount}
       />
       <Stack.Screen
-        name="ConfirmEmail"
+        name='ConfirmEmail'
         options={{
           title: 'Paso 3 de 4',
           headerStyle: {
@@ -51,7 +51,7 @@ const NavigationLogin = () => {
         component={ConfirmEmail}
       />
       <Stack.Screen
-        name="ContactInformation"
+        name='ContactInformation'
         options={{
           title: 'Paso 4 de 4',
           headerStyle: {

--- a/src/screens/ConfirmEmail.js
+++ b/src/screens/ConfirmEmail.js
@@ -12,7 +12,7 @@ import {Colors} from '../utils/Colors';
 import {NEXT_MESSAGE} from '../utils/Constants';
 import CodeConfirmTxtInput from '../components/CodeConfirmTxtInput';
 
-const ConfirmEmail = ({route}) => {
+const ConfirmEmail = ({route, navigation}) => {
   const {usersEmail} = route.params;
   const fieldId = ['fieldOne', 'fieldTwo', 'fieldThree', 'fieldFour'];
   let codeConfirmation = ['1', '2', '3', '4'];
@@ -63,6 +63,7 @@ const ConfirmEmail = ({route}) => {
       });
       if (auxiliarCounter === 4) {
         Alert.alert('Codigo correcto');
+        navigation.navigate('ContactInformation');
       } else {
         Alert.alert('El codigo es incorrecto');
       }

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-quotes */
 import React from 'react';
 import {
   SafeAreaView,
@@ -27,8 +28,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired="Recomendado"
-            keyboard="default"
+            isRequired='Recomendado'
+            keyboard='default'
           />
         );
       } else {
@@ -37,8 +38,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired="Recomendado"
-            keyboard="phone-pad"
+            isRequired='Recomendado'
+            keyboard='phone-pad'
           />
         );
       }

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-quotes */
 import React from 'react';
 import {
   SafeAreaView,
@@ -28,8 +27,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired='Recomendado'
-            keyboard='default'
+            isRequired="Recomendado"
+            keyboard="default"
           />
         );
       } else {
@@ -38,8 +37,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired='Recomendado'
-            keyboard='phone-pad'
+            isRequired="Recomendado"
+            keyboard="phone-pad"
           />
         );
       }

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -1,10 +1,62 @@
 import React from 'react';
-import {SafeAreaView, Text, StyleSheet} from 'react-native';
+import {
+  SafeAreaView,
+  ScrollView,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import {NEXT_MESSAGE} from '../utils/Constants';
+import {Colors} from '../utils/Colors';
+import DescContactInfo from '../components/DescContactInfo';
+import EmailPassTxtInput from '../components/EmailPassTxtInput';
 
 const ContactInformation = () => {
+  const titleInput = ['Nombre', 'Teléfono'];
+
+  const putInputs = () => {
+    const inputs = titleInput.map((element) => {
+      if (element === 'Nombre') {
+        return (
+          <EmailPassTxtInput
+            key={element}
+            id={element}
+            title={element}
+            isRequired="Recomendado"
+            keyboard="default"
+          />
+        );
+      } else {
+        return (
+          <EmailPassTxtInput
+            key={element}
+            id={element}
+            title={element}
+            isRequired="Recomendado"
+            keyboard="phone-pad"
+          />
+        );
+      }
+    });
+    return inputs;
+  };
+
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Información de Contacto</Text>
+      <ScrollView>
+        <Text style={styles.title}>Información de Contacto</Text>
+        <DescContactInfo />
+        <View style={styles.formContainer}>
+          {putInputs()}
+          <Text style={styles.suggestText}>
+            De preferencia un número de celular
+          </Text>
+          <TouchableOpacity style={styles.btnNext}>
+            <Text style={styles.txtNext}>{NEXT_MESSAGE}</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -18,5 +70,28 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 25,
     textAlign: 'center',
+    marginVertical: 25,
+  },
+  formContainer: {
+    marginVertical: 20,
+  },
+  suggestText: {
+    paddingHorizontal: 15,
+    fontStyle: 'italic',
+    fontSize: 16,
+  },
+  btnNext: {
+    height: 55,
+    marginVertical: 30,
+    marginHorizontal: 30,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.btnsColor,
+    borderRadius: 60,
+  },
+  txtNext: {
+    color: Colors.white,
+    fontSize: 22,
   },
 });

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {SafeAreaView, Text, StyleSheet} from 'react-native';
+
+const ContactInformation = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Información de Contacto</Text>
+    </SafeAreaView>
+  );
+};
+
+export default ContactInformation;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 25,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -7,7 +7,11 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
-import {NEXT_MESSAGE} from '../utils/Constants';
+import {
+  NEXT_MESSAGE,
+  CONTACT_INFO,
+  PREFERABLY_CELLPHONE,
+} from '../utils/Constants';
 import {Colors} from '../utils/Colors';
 import DescContactInfo from '../components/DescContactInfo';
 import EmailPassTxtInput from '../components/EmailPassTxtInput';
@@ -45,13 +49,11 @@ const ContactInformation = () => {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView>
-        <Text style={styles.title}>Información de Contacto</Text>
+        <Text style={styles.title}>{CONTACT_INFO}</Text>
         <DescContactInfo />
         <View style={styles.formContainer}>
           {putInputs()}
-          <Text style={styles.suggestText}>
-            De preferencia un número de celular
-          </Text>
+          <Text style={styles.suggestText}>{PREFERABLY_CELLPHONE}</Text>
           <TouchableOpacity style={styles.btnNext}>
             <Text style={styles.txtNext}>{NEXT_MESSAGE}</Text>
           </TouchableOpacity>

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -8,3 +8,7 @@ export const PASS_REQUIREMENTS = {
   fourthTerm: 'contener por lo menos 1 dígito',
 };
 export const REREQUEST_PASS = 'Escribe de nuevo la clave';
+export const CONTACT_INFO = 'Información de Contacto';
+export const DESC_CONTACT_INFO =
+  'Esta información servirá para ponernos en contacto contigo más rapido cuando sea necesario';
+export const PREFERABLY_CELLPHONE = ' De preferencia un número de celular';


### PR DESCRIPTION
close #15 
# Description
- Create the "Información de Contacto" screen layout
- Create a new component that stores the instructions of what the user is going to do on the screen 
-  Reuse the EmailPassTxtInput component where the user will type his name and his phone. Also, using props we tell at this component what keyboard we need on each input. 
- Create new navigation until this new screen

## Screenshots 
- Layout of the screen

![Screenshot_1602009892](https://user-images.githubusercontent.com/42794917/95248594-25e71480-07dd-11eb-82d5-2adee4ffe03a.png)

- using the default keyboard on the "Nombre" input
![Screenshot_1602009904](https://user-images.githubusercontent.com/42794917/95248690-47e09700-07dd-11eb-8136-b3adc5ffba17.png)

- using the phone-pad keyboard on the "Teléfono" input
![Screenshot_1602009918](https://user-images.githubusercontent.com/42794917/95248734-5f1f8480-07dd-11eb-984d-a2c92498c3ae.png)

