### PR TITLE
Feature/20 forgot your password screen

### DIFF
--- a/src/components/DescResetPass.js
+++ b/src/components/DescResetPass.js
@@ -12,6 +12,7 @@ const DescResetPass = () => {
 };
 
 export default DescResetPass;
+
 const styles = StyleSheet.create({
   textContainer: {
     marginTop: 25,

--- a/src/components/DescResetPass.js
+++ b/src/components/DescResetPass.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+import {RESET_PASS_INSTRUCTIONS} from '../utils/Constants';
+import {INSTRUCTION_TXT_SIZE} from '../utils/StylesConstants';
+
+const DescResetPass = () => {
+  return (
+    <View style={styles.textContainer}>
+      <Text style={styles.txtInstructions}>{RESET_PASS_INSTRUCTIONS}</Text>
+    </View>
+  );
+};
+
+export default DescResetPass;
+const styles = StyleSheet.create({
+  textContainer: {
+    marginTop: 25,
+    marginBottom: 30,
+  },
+  txtInstructions: {
+    fontSize: INSTRUCTION_TXT_SIZE,
+    textAlign: 'justify',
+    paddingHorizontal: 38,
+  },
+});

--- a/src/navigations/GoSignIn.js
+++ b/src/navigations/GoSignIn.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {createStackNavigator} from '@react-navigation/stack';
 import {Colors} from '../utils/Colors';
-import {LOGIN, RESET_PASS_STEPS,} from '../utils/Constants';
+import {LOGIN, RESET_PASS_STEPS} from '../utils/Constants';
 import SignIn from '../screens/signInScreens/SignIn';
 import ForgotYourPassword from '../screens/signInScreens/ForgotYourPassword';
 

--- a/src/navigations/GoSignIn.js
+++ b/src/navigations/GoSignIn.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import {createStackNavigator} from '@react-navigation/stack';
 import {Colors} from '../utils/Colors';
-import {LOGIN} from '../utils/Constants';
+import {LOGIN, RESET_PASS_STEPS,} from '../utils/Constants';
 import SignIn from '../screens/signInScreens/SignIn';
+import ForgotYourPassword from '../screens/signInScreens/ForgotYourPassword';
 
 const SignInStack = createStackNavigator();
 
@@ -19,6 +20,17 @@ const GoSignIn = () => {
           headerTitleAlign: 'center',
         }}
         component={SignIn}
+      />
+      <SignInStack.Screen
+        name="ForgotYourPassword"
+        options={{
+          title: RESET_PASS_STEPS.step_one,
+          headerStyle: {
+            backgroundColor: Colors.btnsColor,
+          },
+          headerTitleAlign: 'center',
+        }}
+        component={ForgotYourPassword}
       />
     </SignInStack.Navigator>
   );

--- a/src/screens/signInScreens/ForgotYourPassword.js
+++ b/src/screens/signInScreens/ForgotYourPassword.js
@@ -1,15 +1,36 @@
 import React from 'react';
-import {SafeAreaView, View, Text, StyleSheet} from 'react-native';
-import {RESET_PASSWORD, RESET_PASS_INSTRUCTIONS} from '../../utils/Constants';
-import {TITLE_SIZE, INSTRUCTION_TXT_SIZE} from '../../utils/StylesConstants';
+import {
+  SafeAreaView,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import {Colors} from '../../utils/Colors';
+import {RESET_PASSWORD} from '../../utils/Constants';
+import {TITLE_SIZE} from '../../utils/StylesConstants';
+import DescResetPass from '../../components/DescResetPass';
+import EmailPassTxtInput from '../../components/EmailPassTxtInput';
 
 const ForgotYourPassword = () => {
   return (
     <SafeAreaView style={styles.mainContainer}>
-      <Text style={styles.title}>{RESET_PASSWORD}</Text>
-      <View>
-        <Text style={styles.txtInstructions}>{RESET_PASS_INSTRUCTIONS}</Text>
-      </View>
+      <ScrollView>
+        <Text style={styles.title}>{RESET_PASSWORD}</Text>
+        <DescResetPass />
+        <EmailPassTxtInput
+          title="Correo electrónico"
+          keyboard="email-address"
+          password={false}
+        />
+        <TouchableOpacity
+          style={styles.resetPassBtn}
+          onPress={() => {
+            console.log('Hello world');
+          }}>
+          <Text style={styles.resetPassTxt}>{RESET_PASSWORD}</Text>
+        </TouchableOpacity>
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -22,12 +43,21 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: TITLE_SIZE,
-    marginVertical: 25,
+    marginTop: 25,
     textAlign: 'center',
   },
-  txtInstructions: {
-    fontSize: INSTRUCTION_TXT_SIZE,
-    textAlign: 'justify',
-    paddingHorizontal: 38,
+  resetPassBtn: {
+    height: 55,
+    marginVertical: 50,
+    marginHorizontal: 30,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.btnsColor,
+    borderRadius: 60,
+  },
+  resetPassTxt: {
+    color: Colors.white,
+    fontSize: 22,
   },
 });

--- a/src/screens/signInScreens/ForgotYourPassword.js
+++ b/src/screens/signInScreens/ForgotYourPassword.js
@@ -7,7 +7,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import {Colors} from '../../utils/Colors';
-import {RESET_PASSWORD} from '../../utils/Constants';
+import {RESET_PASSWORD, EMAIL} from '../../utils/Constants';
 import {TITLE_SIZE} from '../../utils/StylesConstants';
 import DescResetPass from '../../components/DescResetPass';
 import EmailPassTxtInput from '../../components/EmailPassTxtInput';
@@ -19,7 +19,7 @@ const ForgotYourPassword = () => {
         <Text style={styles.title}>{RESET_PASSWORD}</Text>
         <DescResetPass />
         <EmailPassTxtInput
-          title="Correo electrónico"
+          title={EMAIL}
           keyboard="email-address"
           password={false}
         />

--- a/src/screens/signInScreens/ForgotYourPassword.js
+++ b/src/screens/signInScreens/ForgotYourPassword.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {SafeAreaView, View, Text, StyleSheet} from 'react-native';
+import {RESET_PASSWORD, RESET_PASS_INSTRUCTIONS} from '../../utils/Constants';
+import {TITLE_SIZE, INSTRUCTION_TXT_SIZE} from '../../utils/StylesConstants';
+
+const ForgotYourPassword = () => {
+  return (
+    <SafeAreaView style={styles.mainContainer}>
+      <Text style={styles.title}>{RESET_PASSWORD}</Text>
+      <View>
+        <Text style={styles.txtInstructions}>{RESET_PASS_INSTRUCTIONS}</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default ForgotYourPassword;
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: TITLE_SIZE,
+    marginVertical: 25,
+    textAlign: 'center',
+  },
+  txtInstructions: {
+    fontSize: INSTRUCTION_TXT_SIZE,
+    textAlign: 'justify',
+    paddingHorizontal: 38,
+  },
+});

--- a/src/screens/signInScreens/SignIn.js
+++ b/src/screens/signInScreens/SignIn.js
@@ -48,7 +48,7 @@ const SignIn = ({navigation}) => {
         <TouchableOpacity
           style={styles.labelBtns}
           onPress={() => {
-            console.log('Hello world');
+            navigation.navigate('ForgotYourPassword');
           }}>
           <Text style={styles.textBtns}>{FORGOT_PASSWORD}</Text>
         </TouchableOpacity>

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -17,3 +17,11 @@ export const FORGOT_PASSWORD = '¿Olvidaste tu clave?';
 export const LOGIN = 'Inicio de sesión';
 export const EMAIL = 'Correo electrónico';
 export const PASSWORD = 'Clave';
+export const RESET_PASS_STEPS = {
+  step_one: 'Paso 1 de 2',
+  step_two: 'Paso 2 de 2',
+  step_three: 'Clave restablecida',
+};
+export const RESET_PASSWORD = 'Restablecer clave';
+export const RESET_PASS_INSTRUCTIONS =
+  'Por favor, captua la dirección de correo con la que te registraste. Te enviaremos un código para restablecer tu clave';

--- a/src/utils/StylesConstants.js
+++ b/src/utils/StylesConstants.js
@@ -1,0 +1,2 @@
+export const TITLE_SIZE = 25;
+export const INSTRUCTION_TXT_SIZE = 18;


### PR DESCRIPTION
closes #20 
This screen is for the users that don't have an account but, they for a mistake touch the button "Iniciar session" and then they need to go back to touch "Registro" button to create their account.
So with this screen, we prevent that the users need to go back and select the "Registro" button, they just touch the **"¿No tienes cuenta? Regístrate"** button and that's all.

# Description
- Create the Forgot password screen 
- Navigate when touching the button "¿No tienes cuenta? Regístrate" into this screen

## Screenshots 
- Screen layout

![Screenshot_1602885511](https://user-images.githubusercontent.com/42794917/96316922-547e9f80-0fd4-11eb-94ce-e5550d102e1d.png)


- Navigation into Forgot your password

![ResetPasswordScreen](https://user-images.githubusercontent.com/42794917/96316982-58aabd00-0fd4-11eb-9cc9-ccf8993cf602.gif)
