### PR TITLE
Feature/23 reset password confirmation

### DIFF
--- a/src/components/CodeConfirmTxtInput.js
+++ b/src/components/CodeConfirmTxtInput.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput, StyleSheet} from 'react-native';
 import {Colors} from '../utils/Colors';
+import PropTypes from 'prop-types';
 
 const CodeConfirmTxtInput = (props) => {
   return (
@@ -15,6 +16,12 @@ const CodeConfirmTxtInput = (props) => {
       }
     />
   );
+};
+
+CodeConfirmTxtInput.prototype = {
+  id: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChangeText: PropTypes.string.isRequired,
 };
 
 export default CodeConfirmTxtInput;

--- a/src/components/ConfirmEmailCode.js
+++ b/src/components/ConfirmEmailCode.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+import {RESET_YOUR_PASSWORD} from '../utils/Constants';
+
+const ConfirmEmailCode = (props) => {
+  return (
+    <View>
+      <Text style={styles.textInstruction}>
+        {RESET_YOUR_PASSWORD.instructions}{' '}
+        <Text style={styles.userEmail}>{props.usersEmail}</Text>
+      </Text>
+    </View>
+  );
+};
+
+export default ConfirmEmailCode;
+
+const styles = StyleSheet.create({
+  textInstruction: {
+    fontSize: 18,
+    textAlign: 'center',
+    paddingHorizontal: 30,
+  },
+  userEmail: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/ConfirmEmailCode.js
+++ b/src/components/ConfirmEmailCode.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {RESET_YOUR_PASSWORD} from '../utils/Constants';
+import PropTypes from 'prop-types';
 
 const ConfirmEmailCode = (props) => {
   return (
@@ -11,6 +12,10 @@ const ConfirmEmailCode = (props) => {
       </Text>
     </View>
   );
+};
+
+ConfirmEmailCode.prototype = {
+  usersEmail: PropTypes.string.isRequired,
 };
 
 export default ConfirmEmailCode;

--- a/src/components/EmailPassTxtInput.js
+++ b/src/components/EmailPassTxtInput.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Text, TextInput, StyleSheet} from 'react-native';
 import {Colors} from '../utils/Colors';
+import PropTypes from 'prop-types';
 
 const EmailPassTxtInput = (props) => {
   return (
@@ -18,6 +19,13 @@ const EmailPassTxtInput = (props) => {
       />
     </View>
   );
+};
+
+EmailPassTxtInput.PropTypes = {
+  title: PropTypes.string.isRequired,
+  isRequired: PropTypes.string,
+  password: PropTypes.bool.isRequired,
+  keyboard: PropTypes.string.isRequired,
 };
 
 export default EmailPassTxtInput;

--- a/src/navigations/GoSignIn.js
+++ b/src/navigations/GoSignIn.js
@@ -4,6 +4,7 @@ import {Colors} from '../utils/Colors';
 import {LOGIN, RESET_PASS_STEPS} from '../utils/Constants';
 import SignIn from '../screens/signInScreens/SignIn';
 import ForgotYourPassword from '../screens/signInScreens/ForgotYourPassword';
+import ResetPassConfirm from '../screens/signInScreens/ResetPassConfirm';
 
 const SignInStack = createStackNavigator();
 
@@ -31,6 +32,17 @@ const GoSignIn = () => {
           headerTitleAlign: 'center',
         }}
         component={ForgotYourPassword}
+      />
+      <SignInStack.Screen
+        name="ResetPassConfirm"
+        options={{
+          title: RESET_PASS_STEPS.step_two,
+          headerStyle: {
+            backgroundColor: Colors.btnsColor,
+          },
+          headerTitleAlign: 'center',
+        }}
+        component={ResetPassConfirm}
       />
     </SignInStack.Navigator>
   );

--- a/src/screens/signInScreens/ForgotYourPassword.js
+++ b/src/screens/signInScreens/ForgotYourPassword.js
@@ -12,7 +12,7 @@ import {TITLE_SIZE} from '../../utils/StylesConstants';
 import DescResetPass from '../../components/DescResetPass';
 import EmailPassTxtInput from '../../components/EmailPassTxtInput';
 
-const ForgotYourPassword = () => {
+const ForgotYourPassword = ({navigation}) => {
   return (
     <SafeAreaView style={styles.mainContainer}>
       <ScrollView>
@@ -26,7 +26,7 @@ const ForgotYourPassword = () => {
         <TouchableOpacity
           style={styles.resetPassBtn}
           onPress={() => {
-            console.log('Hello world');
+            navigation.navigate('ResetPassConfirm');
           }}>
           <Text style={styles.resetPassTxt}>{RESET_PASSWORD}</Text>
         </TouchableOpacity>

--- a/src/screens/signInScreens/ForgotYourPassword.js
+++ b/src/screens/signInScreens/ForgotYourPassword.js
@@ -26,7 +26,9 @@ const ForgotYourPassword = ({navigation}) => {
         <TouchableOpacity
           style={styles.resetPassBtn}
           onPress={() => {
-            navigation.navigate('ResetPassConfirm');
+            navigation.navigate('ResetPassConfirm', {
+              usersEmail: 'sent.email@domain.com',
+            });
           }}>
           <Text style={styles.resetPassTxt}>{RESET_PASSWORD}</Text>
         </TouchableOpacity>

--- a/src/screens/signInScreens/ResetPassConfirm.js
+++ b/src/screens/signInScreens/ResetPassConfirm.js
@@ -1,15 +1,30 @@
 import React from 'react';
-import {SafeAreaView, ScrollView, View, Text, StyleSheet} from 'react-native';
-import {RESET_YOUR_PASSWORD} from '../../utils/Constants';
+import {
+  SafeAreaView,
+  ScrollView,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import {
+  RESET_YOUR_PASSWORD,
+  DONT_RECEIVE_YOUR_CODE,
+  IS_REQUIRED,
+  RESET_PASSWORD,
+} from '../../utils/Constants';
 import {TITLE_SIZE, TITLE_MARGIN_VERTICAL} from '../../utils/StylesConstants';
+import {Colors} from '../../utils/Colors';
 import ConfirmEmailCode from '../../components/ConfirmEmailCode';
 import CodeConfirmTxtInput from '../../components/CodeConfirmTxtInput';
+import EmailPassTxtInput from '../../components/EmailPassTxtInput';
+import PasswordRequirements from '../../components/PasswordRequirements';
 
 const ResetPassConfirm = ({route}) => {
   const {usersEmail} = route.params;
   const fieldId = ['fieldOne', 'fieldTwo', 'fieldThree', 'fieldFour'];
 
-  const showInputs = () => {
+  const showInputsCode = () => {
     return fieldId.map((field) => {
       return <CodeConfirmTxtInput key={field} />;
     });
@@ -21,7 +36,40 @@ const ResetPassConfirm = ({route}) => {
         <Text style={styles.title}>{RESET_YOUR_PASSWORD.title}</Text>
         <View style={styles.codeConfirmContainer}>
           <ConfirmEmailCode usersEmail={usersEmail} />
-          <View style={styles.codeConfirmInputsContainer}>{showInputs()}</View>
+          <View style={styles.codeConfirmInputsContainer}>
+            {showInputsCode()}
+          </View>
+        </View>
+        <View style={styles.requireNewCodeContainer}>
+          <Text style={styles.newCodeInstructions}>
+            {DONT_RECEIVE_YOUR_CODE.title}
+          </Text>
+          <Text style={styles.newCodeInstructions}>
+            {DONT_RECEIVE_YOUR_CODE.instructions}
+          </Text>
+          <TouchableOpacity
+            style={styles.sendNewCodeBtn}
+            onPress={() => console.log('Hello world')}>
+            <Text style={styles.sendNewCodeTxt}>
+              {DONT_RECEIVE_YOUR_CODE.button}
+            </Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.passInputsContainer}>
+          <EmailPassTxtInput
+            title="Nueva clave"
+            isRequired={IS_REQUIRED.toLocaleLowerCase()}
+            password={true}
+          />
+          <PasswordRequirements />
+          <EmailPassTxtInput
+            title="Escribe de nueva clave"
+            isRequired={IS_REQUIRED.toLocaleLowerCase()}
+            password={true}
+          />
+          <TouchableOpacity style={styles.resetBtn}>
+            <Text style={styles.resetBtnText}>{RESET_PASSWORD}</Text>
+          </TouchableOpacity>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -48,5 +96,39 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginVertical: 20,
+  },
+  requireNewCodeContainer: {
+    flex: 1,
+    paddingLeft: 35,
+    paddingVertical: 15,
+  },
+  newCodeInstructions: {
+    fontSize: 15,
+  },
+  sendNewCodeBtn: {
+    marginTop: 10,
+  },
+  sendNewCodeTxt: {
+    fontSize: 15,
+    color: Colors.btnsColor,
+    fontWeight: 'bold',
+  },
+  passInputsContainer: {
+    flex: 1,
+    paddingVertical: 15,
+  },
+  resetBtn: {
+    flex: 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 30,
+    marginHorizontal: 20,
+    backgroundColor: Colors.btnsColor,
+    borderRadius: 60,
+  },
+  resetBtnText: {
+    color: Colors.white,
+    fontSize: 22,
+    marginVertical: 10,
   },
 });

--- a/src/screens/signInScreens/ResetPassConfirm.js
+++ b/src/screens/signInScreens/ResetPassConfirm.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {SafeAreaView, ScrollView, View, Text, StyleSheet} from 'react-native';
+import {RESET_YOUR_PASSWORD} from '../../utils/Constants';
+import {TITLE_SIZE, TITLE_MARGIN_VERTICAL} from '../../utils/StylesConstants';
+import ConfirmEmailCode from '../../components/ConfirmEmailCode';
+import CodeConfirmTxtInput from '../../components/CodeConfirmTxtInput';
+
+const ResetPassConfirm = ({route}) => {
+  const {usersEmail} = route.params;
+  const fieldId = ['fieldOne', 'fieldTwo', 'fieldThree', 'fieldFour'];
+
+  const showInputs = () => {
+    return fieldId.map((field) => {
+      return <CodeConfirmTxtInput key={field} />;
+    });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView>
+        <Text style={styles.title}>{RESET_YOUR_PASSWORD.title}</Text>
+        <View style={styles.codeConfirmContainer}>
+          <ConfirmEmailCode usersEmail={usersEmail} />
+          <View style={styles.codeConfirmInputsContainer}>{showInputs()}</View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default ResetPassConfirm;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  title: {
+    fontSize: TITLE_SIZE,
+    marginVertical: TITLE_MARGIN_VERTICAL,
+    textAlign: 'center',
+  },
+  codeConfirmContainer: {
+    flex: 2,
+  },
+  codeConfirmInputsContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 20,
+  },
+});

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -24,4 +24,17 @@ export const RESET_PASS_STEPS = {
 };
 export const RESET_PASSWORD = 'Restablecer clave';
 export const RESET_PASS_INSTRUCTIONS =
-  'Por favor, captua la dirección de correo con la que te registraste. Te enviaremos un código para restablecer tu clave';
+  'Por favor, captura la dirección de correo con la que te registraste. Te enviaremos un código para restablecer tu clave';
+export const RESET_YOUR_PASSWORD = {
+  title: 'Establecer nueva clave',
+  instructions: 'Por favor ingresa el código enviado a ',
+};
+export const DONT_RECEIVE_YOUR_CODE = {
+  title: '¿No recibiste el código?',
+  instructions: 'Revisa tu carpeta de correos no deseados',
+  button: 'Enviar código de nuevo',
+};
+export const NEW_PASSWORD = {
+  firstRequirement: 'Nueva clave',
+  secondRequirement: 'Escribe de nuevo la clave',
+};

--- a/src/utils/StylesConstants.js
+++ b/src/utils/StylesConstants.js
@@ -1,2 +1,3 @@
 export const TITLE_SIZE = 25;
+export const TITLE_MARGIN_VERTICAL = 25;
 export const INSTRUCTION_TXT_SIZE = 18;


### PR DESCRIPTION
closes #23 
# Description
- Navigate after the user types his email 
- Pass the user's email by props to display on the new screen at what code we send the new code for confirmation
- Create the layout of the reset pass confirm screen 

  ## Screenshots 

![Screenshot_1603927386](https://user-images.githubusercontent.com/42794917/97507214-4fa9dc00-1942-11eb-9a26-7677f6c9c7eb.png)
![Screenshot_1603927391](https://user-images.githubusercontent.com/42794917/97507215-50427280-1942-11eb-8f18-f3efd8d5154e.png)

