### PR TITLE
Hotfix/30 prop types on screens

### DIFF
--- a/src/components/CodeConfirmTxtInput.js
+++ b/src/components/CodeConfirmTxtInput.js
@@ -18,10 +18,10 @@ const CodeConfirmTxtInput = (props) => {
   );
 };
 
-CodeConfirmTxtInput.prototype = {
+CodeConfirmTxtInput.propTypes = {
   id: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  onChangeText: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  onChangeText: PropTypes.func,
 };
 
 export default CodeConfirmTxtInput;

--- a/src/components/EmailPassTxtInput.js
+++ b/src/components/EmailPassTxtInput.js
@@ -21,7 +21,7 @@ const EmailPassTxtInput = (props) => {
   );
 };
 
-EmailPassTxtInput.PropTypes = {
+EmailPassTxtInput.propTypes = {
   title: PropTypes.string.isRequired,
   isRequired: PropTypes.string,
   password: PropTypes.bool.isRequired,

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -11,6 +11,8 @@ import {
   NEXT_MESSAGE,
   CONTACT_INFO,
   PREFERABLY_CELLPHONE,
+  KEYBOARD_TYPE,
+  RECOMMENDED,
 } from '../utils/Constants';
 import {Colors} from '../utils/Colors';
 import DescContactInfo from '../components/DescContactInfo';
@@ -27,8 +29,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired="Recomendado"
-            keyboard="default"
+            isRequired={RECOMMENDED}
+            keyboard={KEYBOARD_TYPE.default}
             password={false}
           />
         );
@@ -38,8 +40,8 @@ const ContactInformation = () => {
             key={element}
             id={element}
             title={element}
-            isRequired="Recomendado"
-            keyboard="phone-pad"
+            isRequired={RECOMMENDED}
+            keyboard={KEYBOARD_TYPE.numeric}
             password={false}
           />
         );

--- a/src/screens/ContactInformation.js
+++ b/src/screens/ContactInformation.js
@@ -29,6 +29,7 @@ const ContactInformation = () => {
             title={element}
             isRequired="Recomendado"
             keyboard="default"
+            password={false}
           />
         );
       } else {
@@ -39,6 +40,7 @@ const ContactInformation = () => {
             title={element}
             isRequired="Recomendado"
             keyboard="phone-pad"
+            password={false}
           />
         );
       }

--- a/src/screens/RegisterAccount.js
+++ b/src/screens/RegisterAccount.js
@@ -22,17 +22,20 @@ const RegisterAccount = ({navigation}) => {
             title="Correo electrónico"
             isRequired={IS_REQUIRED}
             password={false}
+            keyboard="email-address"
           />
           <EmailPassTxtInput
             title="Clave"
             isRequired={IS_REQUIRED}
             password={true}
+            keyboard="default"
           />
           <PasswordRequirements />
           <EmailPassTxtInput
             title={REREQUEST_PASS}
             isRequired={IS_REQUIRED}
             password={true}
+            keyboard="default"
           />
           <TouchableOpacity
             style={styles.nextBtn}

--- a/src/screens/RegisterAccount.js
+++ b/src/screens/RegisterAccount.js
@@ -8,7 +8,14 @@ import {
   StyleSheet,
 } from 'react-native';
 import {Colors} from '../utils/Colors';
-import {NEXT_MESSAGE, IS_REQUIRED, REREQUEST_PASS} from '../utils/Constants';
+import {
+  NEXT_MESSAGE,
+  IS_REQUIRED,
+  REREQUEST_PASS,
+  EMAIL,
+  PASSWORD,
+  KEYBOARD_TYPE,
+} from '../utils/Constants';
 import EmailPassTxtInput from '../components/EmailPassTxtInput';
 import PasswordRequirements from '../components/PasswordRequirements';
 
@@ -19,23 +26,23 @@ const RegisterAccount = ({navigation}) => {
         <Text style={styles.title}>Crea tu cuenta</Text>
         <View style={styles.formContainer}>
           <EmailPassTxtInput
-            title="Correo electrónico"
+            title={EMAIL}
             isRequired={IS_REQUIRED}
             password={false}
-            keyboard="email-address"
+            keyboard={KEYBOARD_TYPE.email}
           />
           <EmailPassTxtInput
-            title="Clave"
+            title={PASSWORD}
             isRequired={IS_REQUIRED}
             password={true}
-            keyboard="default"
+            keyboard={KEYBOARD_TYPE.default}
           />
           <PasswordRequirements />
           <EmailPassTxtInput
             title={REREQUEST_PASS}
             isRequired={IS_REQUIRED}
             password={true}
-            keyboard="default"
+            keyboard={KEYBOARD_TYPE.default}
           />
           <TouchableOpacity
             style={styles.nextBtn}

--- a/src/screens/signInScreens/ResetPassConfirm.js
+++ b/src/screens/signInScreens/ResetPassConfirm.js
@@ -26,7 +26,7 @@ const ResetPassConfirm = ({route}) => {
 
   const showInputsCode = () => {
     return fieldId.map((field) => {
-      return <CodeConfirmTxtInput key={field} />;
+      return <CodeConfirmTxtInput key={field} id={field} />;
     });
   };
 
@@ -60,12 +60,14 @@ const ResetPassConfirm = ({route}) => {
             title="Nueva clave"
             isRequired={IS_REQUIRED.toLocaleLowerCase()}
             password={true}
+            keyboard="default"
           />
           <PasswordRequirements />
           <EmailPassTxtInput
             title="Escribe de nueva clave"
             isRequired={IS_REQUIRED.toLocaleLowerCase()}
             password={true}
+            keyboard="default"
           />
           <TouchableOpacity style={styles.resetBtn}>
             <Text style={styles.resetBtnText}>{RESET_PASSWORD}</Text>

--- a/src/screens/signInScreens/ResetPassConfirm.js
+++ b/src/screens/signInScreens/ResetPassConfirm.js
@@ -12,6 +12,8 @@ import {
   DONT_RECEIVE_YOUR_CODE,
   IS_REQUIRED,
   RESET_PASSWORD,
+  NEW_PASSWORD,
+  KEYBOARD_TYPE,
 } from '../../utils/Constants';
 import {TITLE_SIZE, TITLE_MARGIN_VERTICAL} from '../../utils/StylesConstants';
 import {Colors} from '../../utils/Colors';
@@ -57,17 +59,17 @@ const ResetPassConfirm = ({route}) => {
         </View>
         <View style={styles.passInputsContainer}>
           <EmailPassTxtInput
-            title="Nueva clave"
+            title={NEW_PASSWORD.firstRequirement}
             isRequired={IS_REQUIRED.toLocaleLowerCase()}
             password={true}
-            keyboard="default"
+            keyboard={KEYBOARD_TYPE.default}
           />
           <PasswordRequirements />
           <EmailPassTxtInput
-            title="Escribe de nueva clave"
+            title={NEW_PASSWORD.secondRequirement}
             isRequired={IS_REQUIRED.toLocaleLowerCase()}
             password={true}
-            keyboard="default"
+            keyboard={KEYBOARD_TYPE.default}
           />
           <TouchableOpacity style={styles.resetBtn}>
             <Text style={styles.resetBtnText}>{RESET_PASSWORD}</Text>

--- a/src/screens/signInScreens/SignIn.js
+++ b/src/screens/signInScreens/SignIn.js
@@ -21,9 +21,23 @@ const SignIn = ({navigation}) => {
   const showInputs = () => {
     return inputType.map((type) => {
       if (type === EMAIL) {
-        return <EmailPassTxtInput key={type} title={EMAIL} password={false} />;
+        return (
+          <EmailPassTxtInput
+            key={type}
+            title={EMAIL}
+            password={false}
+            keyboard="email-address"
+          />
+        );
       }
-      return <EmailPassTxtInput key={type} title={PASSWORD} password={true} />;
+      return (
+        <EmailPassTxtInput
+          key={type}
+          title={PASSWORD}
+          password={true}
+          keyboard="default"
+        />
+      );
     });
   };
 

--- a/src/screens/signInScreens/SignIn.js
+++ b/src/screens/signInScreens/SignIn.js
@@ -11,8 +11,10 @@ import {
   NEXT_MESSAGE,
   DONT_ACCOUNT,
   FORGOT_PASSWORD,
+  KEYBOARD_TYPE,
+  EMAIL,
+  PASSWORD,
 } from '../../utils/Constants';
-import {EMAIL, PASSWORD} from '../../utils/Constants';
 import EmailPassTxtInput from '../../components/EmailPassTxtInput';
 
 const SignIn = ({navigation}) => {
@@ -26,7 +28,7 @@ const SignIn = ({navigation}) => {
             key={type}
             title={EMAIL}
             password={false}
-            keyboard="email-address"
+            keyboard={KEYBOARD_TYPE.email}
           />
         );
       }
@@ -35,7 +37,7 @@ const SignIn = ({navigation}) => {
           key={type}
           title={PASSWORD}
           password={true}
-          keyboard="default"
+          keyboard={KEYBOARD_TYPE.default}
         />
       );
     });

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -38,3 +38,9 @@ export const NEW_PASSWORD = {
   firstRequirement: 'Nueva clave',
   secondRequirement: 'Escribe de nuevo la clave',
 };
+export const KEYBOARD_TYPE = {
+  email: 'email-address',
+  default: 'default',
+  numeric: 'number-pad',
+};
+export const RECOMMENDED = 'Recomendado';


### PR DESCRIPTION
closes #30 
# Description
Using PropTypes on the components check if they are receiving all the props that they required. And when we call at the components not everyone has all the props that they need, so the JS console sends a warning that says that we are not passing the required props.
This Pull Request fix those warnings on the console
